### PR TITLE
Added helper method to ViewingRules class (copyViewingRule)

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1835,6 +1835,10 @@ public:
     /// Do not use (needed only for pybind11).
     virtual ~ViewingRules();
 
+    ///Copy a viewing rule from a source to a destination
+    void copyViewingRule(const ConstViewingRulesRcPtr& src, size_t srcIdx, size_t dstIdx, ViewingRulesRcPtr& rules);
+
+
 private:
     ViewingRules();
 

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1836,7 +1836,8 @@ public:
     virtual ~ViewingRules();
 
     ///Copy a viewing rule from a source to a destination
-    void copyViewingRule(const ConstViewingRulesRcPtr& src, size_t srcIdx, size_t dstIdx, ViewingRulesRcPtr& rules);
+    void copyViewingRule(const ConstViewingRulesRcPtr& src, size_t srcIdx,
+                         size_t dstIdx, ViewingRulesRcPtr& rules);
 
 
 private:

--- a/src/OpenColorIO/ViewingRules.cpp
+++ b/src/OpenColorIO/ViewingRules.cpp
@@ -481,4 +481,45 @@ bool FindRule(ConstViewingRulesRcPtr vr, const std::string & name, size_t & rule
     return false;
 }
 
+void ViewingRules::copyViewingRule(const ConstViewingRulesRcPtr& src, size_t srcIdx,
+                                   size_t dstIdx, ViewingRulesRcPtr& rules)
+{
+    if (dstIdx > rules->getNumEntries())
+    {
+        std::ostringstream oss;
+        oss << "Viewing rules: destination index for copying'" << dstIdx
+            << "' is out of bounds. There are only '" << rules->getNumEntries() << "' entries.";
+        throw Exception(oss.str().c_str());
+    }
+
+    try
+    {
+        rules->insertRule(dstIdx, src->getName(srcIdx));
+
+        const int numColorSpaces = static_cast<int>(src->getNumColorSpaces(srcIdx));
+        for (int i = 0; i < numColorSpaces; i++)
+        {
+            rules->addColorSpace(dstIdx, src->getColorSpace(srcIdx, i));
+        }
+
+        const int numEncodings = static_cast<int>(src->getNumEncodings(srcIdx));
+        for (int i = 0; i < numEncodings; i++)
+        {
+            rules->addEncoding(dstIdx, src->getEncoding(srcIdx, i));
+        }
+
+        const int numCustomKeys = static_cast<int>(src->getNumCustomKeys(srcIdx));
+        for (int i = 0; i < numCustomKeys; i++)
+        {
+            rules->setCustomKey(dstIdx, src->getCustomKeyName(srcIdx, i), src->getCustomKeyValue(srcIdx, i));
+        }
+    }
+    catch (Exception& e)
+    {
+        std::ostringstream oss;
+        oss << "Error copying viewing rule from index '" << srcIdx
+            << "' to index '" << dstIdx << "': " << e.what();
+        throw Exception(oss.str().c_str());
+    }
+}
 } // namespace OCIO_NAMESPACE

--- a/tests/cpu/ViewingRules_tests.cpp
+++ b/tests/cpu/ViewingRules_tests.cpp
@@ -78,6 +78,25 @@ OCIO_ADD_TEST(ViewingRules, basic)
     OCIO_CHECK_EQUAL(stringVal, cs0);
     OCIO_CHECK_NO_THROW(stringVal = vrules->getColorSpace(0, 1));
     OCIO_CHECK_EQUAL(stringVal, cs1);
+
+    // Copy rule 0 to index 2.
+    OCIO_CHECK_NO_THROW(vrules->copyViewingRule(vrules, 0, 2, vrules));
+
+    // Verify the copied rule at index 2 matches the source rule at index 0.
+    OCIO_REQUIRE_EQUAL(vrules->getNumEntries(), 4);
+    OCIO_CHECK_NO_THROW(stringVal = vrules->getName(2));
+    OCIO_CHECK_EQUAL(stringVal, ruleName0);
+    OCIO_CHECK_NO_THROW(numOf = vrules->getNumColorSpaces(2));
+    OCIO_CHECK_EQUAL(numOf, 2);
+    OCIO_CHECK_NO_THROW(stringVal = vrules->getColorSpace(2, 0));
+    OCIO_CHECK_EQUAL(stringVal, cs0);
+    OCIO_CHECK_NO_THROW(stringVal = vrules->getColorSpace(2, 1));
+    OCIO_CHECK_EQUAL(stringVal, cs1);
+
+    // Remove the copied rule.
+    OCIO_CHECK_NO_THROW(vrules->removeRule(2));
+    OCIO_REQUIRE_EQUAL(vrules->getNumEntries(), 3);
+
     // Can not access non existing colorspaces.
     OCIO_CHECK_THROW_WHAT(vrules->getColorSpace(0, 2), OCIO::Exception,
                           "rule 'Rule0' at index '0': colorspace index '2' is invalid.");
@@ -123,6 +142,24 @@ OCIO_ADD_TEST(ViewingRules, basic)
     OCIO_CHECK_EQUAL(stringVal, enc1);
     // Re-add encoding.
     OCIO_CHECK_NO_THROW(vrules->addEncoding(1, enc0.c_str()));
+
+    // Copy rule 1 to index 3.
+    OCIO_CHECK_NO_THROW(vrules->copyViewingRule(vrules, 1, 3, vrules));
+
+    // Verify the copied rule at index 3 matches the source rule at index 1.
+    OCIO_REQUIRE_EQUAL(vrules->getNumEntries(), 4);
+    OCIO_CHECK_NO_THROW(stringVal = vrules->getName(3));
+    OCIO_CHECK_EQUAL(stringVal, ruleName1);
+    OCIO_CHECK_NO_THROW(numOf = vrules->getNumEncodings(3));
+    OCIO_CHECK_EQUAL(numOf, 2);
+    OCIO_CHECK_NO_THROW(stringVal = vrules->getEncoding(3, 0));
+    OCIO_CHECK_EQUAL(stringVal, enc0);
+    OCIO_CHECK_NO_THROW(stringVal = vrules->getEncoding(3, 1));
+    OCIO_CHECK_EQUAL(stringVal, enc1);
+
+    // Remove the copied rule.
+    OCIO_CHECK_NO_THROW(vrules->removeRule(3));
+    OCIO_REQUIRE_EQUAL(vrules->getNumEntries(), 3);
 
     // Same with custom keys.
     const std::string key0{ "key0" };


### PR DESCRIPTION
Related to issue #2050.

I implemented void copyViewingRule helper function for the ViewingRules class. 

I followed the skeleton for desired functionality, changing a few things and adding an initial check for destination index bounds based on what I had seen in other ViewingRules class functions. 

I also added unit tests. I based them off of nearby tests, using what was already implemented. 

